### PR TITLE
chore: migrate from chrono's deprecated method

### DIFF
--- a/crates/datetime/src/components/global_datetime.rs
+++ b/crates/datetime/src/components/global_datetime.rs
@@ -1,6 +1,6 @@
 use crate::tokens::{TOKEN_SPACE, TOKEN_T};
 use crate::{parse_date_component, parse_time_component, parse_timezone_offset_component};
-use chrono::{DateTime, Duration, NaiveDateTime, Utc};
+use chrono::{DateTime, Duration, NaiveDateTime, Utc, TimeZone};
 
 /// Parse a [proleptic-Gregorian date][proleptic-greg] consisting
 /// of a date, time, and an optional time-zone offset
@@ -57,24 +57,23 @@ pub fn parse_global_datetime(s: &str) -> Option<DateTime<Utc>> {
 		time.overflowing_sub_signed(timezone_offset_as_duration).0,
 	);
 
-	Some(DateTime::<Utc>::from_utc(naive_datetime, Utc))
+	Some(Utc.from_utc_datetime(&naive_datetime))
 }
 
 #[cfg(test)]
 mod tests {
 	use super::parse_global_datetime;
-	use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+	use chrono::{NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 
 	#[test]
 	fn test_parse_global_datetime_t_hm() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31T12:31"),
-			Some(DateTime::<Utc>::from_utc(
-				NaiveDateTime::new(
+			Some(Utc.from_utc_datetime(
+				&NaiveDateTime::new(
 					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
 					NaiveTime::from_hms_opt(12, 31, 0).unwrap(),
 				),
-				Utc
 			))
 		);
 	}
@@ -83,12 +82,11 @@ mod tests {
 	fn test_parse_global_datetime_t_hms() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31T12:31:59"),
-			Some(DateTime::<Utc>::from_utc(
-				NaiveDateTime::new(
+			Some(Utc.from_utc_datetime(
+				&NaiveDateTime::new(
 					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
 					NaiveTime::from_hms_opt(12, 31, 59).unwrap(),
 				),
-				Utc
 			))
 		);
 	}
@@ -97,12 +95,11 @@ mod tests {
 	fn test_parse_global_datetime_t_hms_milliseconds() {
 		assert_eq!(
 			parse_global_datetime("2027-11-29T12:31:59.123"),
-			Some(DateTime::<Utc>::from_utc(
-				NaiveDateTime::new(
+			Some(Utc.from_utc_datetime(
+				&NaiveDateTime::new(
 					NaiveDate::from_ymd_opt(2027, 11, 29).unwrap(),
 					NaiveTime::from_hms_milli_opt(12, 31, 59, 123).unwrap(),
 				),
-				Utc
 			))
 		);
 	}
@@ -111,12 +108,11 @@ mod tests {
 	fn test_parse_global_datetime_t_hms_z() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31T12:31:59Z"),
-			Some(DateTime::<Utc>::from_utc(
-				NaiveDateTime::new(
+			Some(Utc.from_utc_datetime(
+				&NaiveDateTime::new(
 					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
 					NaiveTime::from_hms_opt(12, 31, 59).unwrap(),
 				),
-				Utc
 			))
 		);
 	}
@@ -125,12 +121,11 @@ mod tests {
 	fn test_parse_global_datetime_space_hm() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31 12:31"),
-			Some(DateTime::<Utc>::from_utc(
-				NaiveDateTime::new(
+			Some(Utc.from_utc_datetime(
+				&NaiveDateTime::new(
 					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
 					NaiveTime::from_hms_opt(12, 31, 0).unwrap(),
 				),
-				Utc
 			))
 		);
 	}
@@ -139,12 +134,11 @@ mod tests {
 	fn test_parse_global_datetime_space_hms() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31 12:31:59"),
-			Some(DateTime::<Utc>::from_utc(
-				NaiveDateTime::new(
+			Some(Utc.from_utc_datetime(
+				&NaiveDateTime::new(
 					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
 					NaiveTime::from_hms_opt(12, 31, 59).unwrap(),
 				),
-				Utc
 			))
 		);
 	}
@@ -153,12 +147,11 @@ mod tests {
 	fn test_parse_global_datetime_space_hms_milliseconds() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31 12:31:59.123"),
-			Some(DateTime::<Utc>::from_utc(
-				NaiveDateTime::new(
+			Some(Utc.from_utc_datetime(
+				&NaiveDateTime::new(
 					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
 					NaiveTime::from_hms_milli_opt(12, 31, 59, 123).unwrap(),
 				),
-				Utc
 			))
 		);
 	}

--- a/crates/datetime/src/components/global_datetime.rs
+++ b/crates/datetime/src/components/global_datetime.rs
@@ -127,7 +127,7 @@ mod tests {
 			Some(Utc.from_utc_datetime(&NaiveDateTime::new(
 				NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
 				NaiveTime::from_hms_opt(12, 31, 59).unwrap(),
-			),))
+			)))
 		);
 	}
 

--- a/crates/datetime/src/components/global_datetime.rs
+++ b/crates/datetime/src/components/global_datetime.rs
@@ -1,6 +1,6 @@
 use crate::tokens::{TOKEN_SPACE, TOKEN_T};
 use crate::{parse_date_component, parse_time_component, parse_timezone_offset_component};
-use chrono::{DateTime, Duration, NaiveDateTime, Utc, TimeZone};
+use chrono::{DateTime, Duration, NaiveDateTime, TimeZone, Utc};
 
 /// Parse a [proleptic-Gregorian date][proleptic-greg] consisting
 /// of a date, time, and an optional time-zone offset
@@ -69,12 +69,10 @@ mod tests {
 	fn test_parse_global_datetime_t_hm() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31T12:31"),
-			Some(Utc.from_utc_datetime(
-				&NaiveDateTime::new(
-					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
-					NaiveTime::from_hms_opt(12, 31, 0).unwrap(),
-				),
-			))
+			Some(Utc.from_utc_datetime(&NaiveDateTime::new(
+				NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
+				NaiveTime::from_hms_opt(12, 31, 0).unwrap(),
+			)))
 		);
 	}
 
@@ -82,12 +80,10 @@ mod tests {
 	fn test_parse_global_datetime_t_hms() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31T12:31:59"),
-			Some(Utc.from_utc_datetime(
-				&NaiveDateTime::new(
-					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
-					NaiveTime::from_hms_opt(12, 31, 59).unwrap(),
-				),
-			))
+			Some(Utc.from_utc_datetime(&NaiveDateTime::new(
+				NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
+				NaiveTime::from_hms_opt(12, 31, 59).unwrap(),
+			)))
 		);
 	}
 
@@ -95,12 +91,10 @@ mod tests {
 	fn test_parse_global_datetime_t_hms_milliseconds() {
 		assert_eq!(
 			parse_global_datetime("2027-11-29T12:31:59.123"),
-			Some(Utc.from_utc_datetime(
-				&NaiveDateTime::new(
-					NaiveDate::from_ymd_opt(2027, 11, 29).unwrap(),
-					NaiveTime::from_hms_milli_opt(12, 31, 59, 123).unwrap(),
-				),
-			))
+			Some(Utc.from_utc_datetime(&NaiveDateTime::new(
+				NaiveDate::from_ymd_opt(2027, 11, 29).unwrap(),
+				NaiveTime::from_hms_milli_opt(12, 31, 59, 123).unwrap(),
+			)))
 		);
 	}
 
@@ -108,12 +102,10 @@ mod tests {
 	fn test_parse_global_datetime_t_hms_z() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31T12:31:59Z"),
-			Some(Utc.from_utc_datetime(
-				&NaiveDateTime::new(
-					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
-					NaiveTime::from_hms_opt(12, 31, 59).unwrap(),
-				),
-			))
+			Some(Utc.from_utc_datetime(&NaiveDateTime::new(
+				NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
+				NaiveTime::from_hms_opt(12, 31, 59).unwrap(),
+			)))
 		);
 	}
 
@@ -121,12 +113,10 @@ mod tests {
 	fn test_parse_global_datetime_space_hm() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31 12:31"),
-			Some(Utc.from_utc_datetime(
-				&NaiveDateTime::new(
-					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
-					NaiveTime::from_hms_opt(12, 31, 0).unwrap(),
-				),
-			))
+			Some(Utc.from_utc_datetime(&NaiveDateTime::new(
+				NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
+				NaiveTime::from_hms_opt(12, 31, 0).unwrap(),
+			)))
 		);
 	}
 
@@ -134,12 +124,10 @@ mod tests {
 	fn test_parse_global_datetime_space_hms() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31 12:31:59"),
-			Some(Utc.from_utc_datetime(
-				&NaiveDateTime::new(
-					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
-					NaiveTime::from_hms_opt(12, 31, 59).unwrap(),
-				),
-			))
+			Some(Utc.from_utc_datetime(&NaiveDateTime::new(
+				NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
+				NaiveTime::from_hms_opt(12, 31, 59).unwrap(),
+			),))
 		);
 	}
 
@@ -147,12 +135,10 @@ mod tests {
 	fn test_parse_global_datetime_space_hms_milliseconds() {
 		assert_eq!(
 			parse_global_datetime("2004-12-31 12:31:59.123"),
-			Some(Utc.from_utc_datetime(
-				&NaiveDateTime::new(
-					NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
-					NaiveTime::from_hms_milli_opt(12, 31, 59, 123).unwrap(),
-				),
-			))
+			Some(Utc.from_utc_datetime(&NaiveDateTime::new(
+				NaiveDate::from_ymd_opt(2004, 12, 31).unwrap(),
+				NaiveTime::from_hms_milli_opt(12, 31, 59, 123).unwrap(),
+			)))
 		);
 	}
 


### PR DESCRIPTION
Migrates from `DateTime::<Utc>::from_utc()` to `Utc.from_utc_datetime()`