### PR TITLE
refactor!(infra): simplify function signatures

### DIFF
--- a/crates/infra/CHANGELOG.md
+++ b/crates/infra/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Implemented `InfraStr` trait for the `String` type (previously only implemented for `str`).
 - Added `skip_codepoints()`, a non-allocating alternative of `collect_codepoints()`.
+- Simplifies the function signatures of the following:
+  - `collect_codepoints()` now takes a generic parameter `P` that must satisfy `Fn(char) -> bool` (previously `FnMut(char) -> bool`)
+  - `skip_codepoints()` now takes a generic parameter `P` that must satisfy `Fn(char) -> bool` (previously `FnMut(char) -> bool`)
+  - `skip_codepoints()` no longer takes a mutable parameter for `predicate` of `P` (now `predicate: P` instead of `mut predicate: P`)
+  - `InfraStr` trait follows suit with the same changes mentioned above
 
 ## 0.2.2 (2023-11-08)
 

--- a/crates/infra/src/strings.rs
+++ b/crates/infra/src/strings.rs
@@ -14,11 +14,11 @@ pub trait InfraStr {
 	/// See the documentation for [`collect_codepoints()`]
 	fn collect_codepoints<P>(&self, position: &mut usize, predicate: P) -> String
 	where
-		P: FnMut(char) -> bool;
+		P: Fn(char) -> bool;
 	/// See the documentation for [`skip_codepoints()`]
 	fn skip_codepoints<P>(&self, position: &mut usize, predicate: P)
 	where
-		P: FnMut(char) -> bool;
+		P: Fn(char) -> bool;
 }
 
 impl InfraStr for str {
@@ -40,14 +40,14 @@ impl InfraStr for str {
 
 	fn collect_codepoints<P>(&self, position: &mut usize, predicate: P) -> String
 	where
-		P: FnMut(char) -> bool,
+		P: Fn(char) -> bool,
 	{
 		collect_codepoints(self, position, predicate)
 	}
 
 	fn skip_codepoints<P>(&self, position: &mut usize, predicate: P)
 	where
-		P: FnMut(char) -> bool,
+		P: Fn(char) -> bool,
 	{
 		skip_codepoints(self, position, predicate)
 	}
@@ -72,14 +72,14 @@ impl InfraStr for String {
 
 	fn collect_codepoints<P>(&self, position: &mut usize, predicate: P) -> String
 	where
-		P: FnMut(char) -> bool,
+		P: Fn(char) -> bool,
 	{
 		collect_codepoints(self.as_str(), position, predicate)
 	}
 
 	fn skip_codepoints<P>(&self, position: &mut usize, predicate: P)
 	where
-		P: FnMut(char) -> bool,
+		P: Fn(char) -> bool,
 	{
 		skip_codepoints(self.as_str(), position, predicate)
 	}
@@ -220,7 +220,7 @@ pub fn trim_collapse_ascii_whitespace(s: &str) -> String {
 /// ```
 pub fn collect_codepoints<P>(s: &str, position: &mut usize, predicate: P) -> String
 where
-	P: FnMut(char) -> bool,
+	P: Fn(char) -> bool,
 {
 	if s.is_empty() || position >= &mut s.len() {
 		return String::new();
@@ -254,9 +254,9 @@ where
 /// assert_eq!(position, 5);
 /// assert_eq!(&s[position..], "_bob");
 /// ```
-pub fn skip_codepoints<P>(s: &str, position: &mut usize, mut predicate: P)
+pub fn skip_codepoints<P>(s: &str, position: &mut usize, predicate: P)
 where
-	P: FnMut(char) -> bool,
+	P: Fn(char) -> bool,
 {
 	if s.is_empty() || position >= &mut s.len() {
 		return;


### PR DESCRIPTION
Simplifies the function signatures of the following:
 - `collect_codepoints()` now takes a generic parameter `P` that must satisfy `Fn(char) -> bool` (previously `FnMut(char) -> bool`)
 - `skip_codepoints()` now takes a generic parameter `P` that must satisfy `Fn(char) -> bool` (previously `FnMut(char) -> bool`)
 - `skip_codepoints()` no longer takes a mutable parameter for `predicate` of `P` (now `predicate: P` instead of `mut predicate: P`)
 - `InfraStr` trait follows suit with the same changes mentioned above