### PR TITLE
chore: cleanup crate metadata

### DIFF
--- a/crates/datetime/Cargo.toml
+++ b/crates/datetime/Cargo.toml
@@ -5,7 +5,6 @@ authors = [
 	"Samantha Nguyen, <contact@samanthanguyen.me>",
 ]
 description = "A Rust crate for parsing the datetime microsyntax, as defined by the WHATWG HTML Standard"
-homepage = "https://github.com/neoncitylights/whatwg-rust"
 repository = "https://github.com/neoncitylights/whatwg-rust"
 documentation = "https://docs.rs/whatwg-datetime"
 readme = "README.md"
@@ -13,19 +12,6 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 keywords = ["whatwg", "html", "html-datetime", "datetime"]
 categories = ["parsing", "text-processing"]
-exclude = [
-	".devcontainer",
-	".github",
-	".vscode",
-	".idea",
-	"deny.toml",
-	".commitlintrc.json",
-	"package.json",
-	"package-lock.json",
-	"fuzz",
-	"book",
-	"benches",
-]
 
 [dependencies]
 # chrono < 0.5 brings in a deprecated version of the `time` crate via `oldtime` feature by default

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -5,26 +5,11 @@ authors = [
 	"Samantha Nguyen, <contact@samanthanguyen.me>",
 ]
 description = "Tiny Rust-based implementation of the WHATWG Infra Standard"
-homepage = "https://github.com/neoncitylights/whatwg-rust"
 repository = "https://github.com/neoncitylights/whatwg-rust"
 documentation = "https://docs.rs/whatwg-infra"
-keywords = ["whatwg", "infra", "spec", "specification", "standard"]
-categories = ["no-std", "parsing", "text-processing"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
-edition = "2021"
 rust-version = "1.63.0"
-
-exclude = [
-	".devcontainer",
-	".github",
-	".vscode",
-	".idea",
-	"deny.toml",
-	".commitlintrc.json",
-	"package.json",
-	"package-lock.json",
-	"fuzz",
-	"book",
-	"benches",
-]
+edition = "2021"
+keywords = ["whatwg", "infra", "spec", "specification", "standard"]
+categories = ["no-std", "parsing", "text-processing"]


### PR DESCRIPTION
- remove `homepage` since the URL isn't distinct from the `repository` URL
- remove `exclude` field since these are no longer included with the repository configured as a monorepo
- consistent order of keys between crates