### PR TITLE
chore: apply clippy fixes (use spaces in docblock code)

### DIFF
--- a/crates/datetime/src/components/global_datetime.rs
+++ b/crates/datetime/src/components/global_datetime.rs
@@ -15,13 +15,13 @@ use chrono::{DateTime, Duration, NaiveDateTime, TimeZone, Utc};
 /// use whatwg_datetime::parse_global_datetime;
 ///
 /// assert_eq!(
-/// 	parse_global_datetime("2011-11-18T14:54Z"),
-/// 	Some(Utc.from_utc_datetime(
-/// 		&NaiveDateTime::new(
-/// 			NaiveDate::from_ymd_opt(2011, 11, 18).unwrap(),
-/// 			NaiveTime::from_hms_opt(14, 54, 0).unwrap(),
-/// 		)
-/// 	))
+///     parse_global_datetime("2011-11-18T14:54Z"),
+///     Some(Utc.from_utc_datetime(
+///         &NaiveDateTime::new(
+///             NaiveDate::from_ymd_opt(2011, 11, 18).unwrap(),
+///             NaiveTime::from_hms_opt(14, 54, 0).unwrap(),
+///         )
+///     ))
 /// );
 /// ```
 ///

--- a/crates/datetime/src/lib.rs
+++ b/crates/datetime/src/lib.rs
@@ -1,31 +1,29 @@
-/*!
-A Rust crate for parsing the datetime microsyntax, as defined by the WHATWG HTML Standard.
-
-## Install
-
-```shell
-cargo add whatwg-datetime
-```
-
-## Usage
-
-This library currently implements 8 of the 9 datetime formats defined by the WHATWG HTML Standard. The only format not implemented is the duration format, which is tracked in [issue #23](https://github.com/neoncitylights/whatwg-rust/issues/23).
-
-```rust
-use chrono::{NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
-use whatwg_datetime::parse_global_datetime;
-
-assert_eq!(
-    parse_global_datetime("2011-11-18T14:54Z"),
-    Some(Utc.from_utc_datetime(
-        &NaiveDateTime::new(
-            NaiveDate::from_ymd_opt(2011, 11, 18).unwrap(),
-            NaiveTime::from_hms_opt(14, 54, 0).unwrap(),
-        )
-    ))
-);
-```
-*/
+//! A Rust crate for parsing the datetime microsyntax, as defined by the WHATWG HTML Standard.
+//!
+//! ## Install
+//!
+//! ```shell
+//! cargo add whatwg-datetime
+//! ```
+//!
+//! ## Usage
+//!
+//! This library currently implements 8 of the 9 datetime formats defined by the WHATWG HTML Standard. The only format not implemented is the duration format, which is tracked in [issue #23](https://github.com/neoncitylights/whatwg-rust/issues/23).
+//!
+//! ```rust
+//! use chrono::{NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
+//! use whatwg_datetime::parse_global_datetime;
+//!
+//! assert_eq!(
+//!     parse_global_datetime("2011-11-18T14:54Z"),
+//!     Some(Utc.from_utc_datetime(
+//!         &NaiveDateTime::new(
+//!             NaiveDate::from_ymd_opt(2011, 11, 18).unwrap(),
+//!             NaiveTime::from_hms_opt(14, 54, 0).unwrap(),
+//!         )
+//!     ))
+//! );
+//! ```
 
 mod components;
 mod utils;

--- a/crates/datetime/src/lib.rs
+++ b/crates/datetime/src/lib.rs
@@ -16,13 +16,13 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use whatwg_datetime::parse_global_datetime;
 
 assert_eq!(
-	parse_global_datetime("2011-11-18T14:54Z"),
-	Some(Utc.from_utc_datetime(
-		&NaiveDateTime::new(
-			NaiveDate::from_ymd_opt(2011, 11, 18).unwrap(),
-			NaiveTime::from_hms_opt(14, 54, 0).unwrap(),
-		)
-	))
+    parse_global_datetime("2011-11-18T14:54Z"),
+    Some(Utc.from_utc_datetime(
+        &NaiveDateTime::new(
+            NaiveDate::from_ymd_opt(2011, 11, 18).unwrap(),
+            NaiveTime::from_hms_opt(14, 54, 0).unwrap(),
+        )
+    ))
 );
 ```
 */

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -1,4 +1,4 @@
-//! //! A tiny Rust crate that implements parts of the WHATWG Infra Standard. Specifically, it implements the following:
+//! A tiny Rust crate that implements parts of the WHATWG Infra Standard. Specifically, it implements the following:
 //!
 //! - [4.5. Code points](https://infra.spec.whatwg.org/#code-points)
 //! - [4.6. Strings](https://infra.spec.whatwg.org/#strings)

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -1,50 +1,47 @@
-/*!
-A tiny Rust crate that implements parts of the WHATWG Infra Standard. Specifically, it implements the following:
-
-- [4.5. Code points](https://infra.spec.whatwg.org/#code-points)
-- [4.6. Strings](https://infra.spec.whatwg.org/#strings)
-
-It exposes a small set of primitives that are useful for parsing text into machine-readable data.
-
-## Install
-
-```shell
-cargo add whatwg-infra
-```
-
-## Usage
-
-You can import individual functions:
-
-```rust
-use whatwg_infra::{
-    is_ascii_tab_newline,
-    is_c0_control,
-    is_c0_control_space,
-    is_noncharacter
-};
-
-assert!(is_ascii_tab_newline('\t'));
-assert!(is_c0_control('\u{0000}'));
-assert!(is_c0_control_space('\u{0020}'));
-
-```
-
-You can also import the traits to get all the functionality, and execute the methods on the types directly.
-
-```rust
-use whatwg_infra::{InfraScalarValue, InfraStr, InfraUtf16Surrogate};
-
-assert_eq!('a'.is_ascii_tab_newline(), false);
-assert_eq!('\u{001E}'.is_c0_control(), true);
-assert_eq!('\n'.is_c0_control_space(), true);
-assert_eq!('\u{CFFFF}'.is_noncharacter(), true);
-```
-
-## no_std
-
-This crate does not depend on libstd, and can be used in `#![no_std]` environments.
-*/
+//! //! A tiny Rust crate that implements parts of the WHATWG Infra Standard. Specifically, it implements the following:
+//!
+//! - [4.5. Code points](https://infra.spec.whatwg.org/#code-points)
+//! - [4.6. Strings](https://infra.spec.whatwg.org/#strings)
+//!
+//! It exposes a small set of primitives that are useful for parsing text into machine-readable data.
+//!
+//! ## Install
+//!
+//! ```shell
+//! cargo add whatwg-infra
+//! ```
+//!
+//! ## Usage
+//!
+//! You can import individual functions:
+//!
+//! ```rust
+//! use whatwg_infra::{
+//!     is_ascii_tab_newline,
+//!     is_c0_control,
+//!     is_c0_control_space,
+//!     is_noncharacter
+//! };
+//!
+//! assert!(is_ascii_tab_newline('\t'));
+//! assert!(is_c0_control('\u{0000}'));
+//! assert!(is_c0_control_space('\u{0020}'));
+//! ```
+//!
+//! You can also import the traits to get all the functionality, and execute the methods on the types directly.
+//!
+//! ```rust
+//! use whatwg_infra::{InfraScalarValue, InfraStr, InfraUtf16Surrogate};
+//!
+//! assert_eq!('a'.is_ascii_tab_newline(), false);
+//! assert_eq!('\u{001E}'.is_c0_control(), true);
+//! assert_eq!('\n'.is_c0_control_space(), true);
+//! assert_eq!('\u{CFFFF}'.is_noncharacter(), true);
+//! ```
+//!
+//! ## no_std
+//!
+//! This crate does not depend on libstd, and can be used in `#![no_std]` environments.
 #![no_std]
 
 /// Detection of UTF-16 surrogate codepoints for `u16`

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -18,10 +18,10 @@ You can import individual functions:
 
 ```rust
 use whatwg_infra::{
-	is_ascii_tab_newline,
-	is_c0_control,
-	is_c0_control_space,
-	is_noncharacter
+    is_ascii_tab_newline,
+    is_c0_control,
+    is_c0_control_space,
+    is_noncharacter
 };
 
 assert!(is_ascii_tab_newline('\t'));


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#tabs_in_doc_comments